### PR TITLE
Update gulp paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "source-map-support": "^0.3.1"
   },
   "scripts": {
-    "prepublish": "./node_modules/.bin/gulp prepublish",
-    "test": "./node_modules/.bin/gulp once",
-    "watch": "./node_modules/.bin/gulp"
+    "prepublish": "gulp prepublish",
+    "test": "gulp once",
+    "watch": "gulp"
   },
   "devDependencies": {
     "appium-gulp-plugins": "^1.2.12",


### PR DESCRIPTION
npm allow use in `package.json` shortened paths because all installed dependencies visible as if it installed globally so don't needed to use relative path.

See: https://docs.npmjs.com/misc/scripts
